### PR TITLE
Update Github CI to use edge instead of develop

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -5,7 +5,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
     branches:
       - main
-      - develop
+      - edge
 
 jobs:
   buildx:


### PR DESCRIPTION
Needed to have the Github CI not fail when renaming the develop branch to edge.